### PR TITLE
Enable GH actions to deploy existing site

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,20 @@
+name: Deploy Roave site
+
+on:
+  push:
+    branches:
+      - develop
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: mkdir pub && cp -avf -t pub css images team CNAME index.html
+      - name: Deploy
+        uses: JamesIves/github-pages-deploy-action@releases/v3
+        with:
+          ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
+          BRANCH: master
+          FOLDER: pub
+          CLEAN: true


### PR DESCRIPTION
PR #2 will introduce a new site, but I wanted to get GH actions deploying the existing site in a conistent way.﻿
